### PR TITLE
fix: lock allwinner-prebuilt package on 1.4.6-3

### DIFF
--- a/pkgs.lock
+++ b/pkgs.lock
@@ -1,0 +1,3 @@
+{
+  "allwinner-prebuilt": "1.4.6-3"
+}


### PR DESCRIPTION
Link: https://github.com/radxa-pkg/allwinner-prebuilt/pull/15#pullrequestreview-3952854988